### PR TITLE
FUL-20785 Bump com.gradle.plugin-publish version to 0.12.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.gradle.plugin-publish" version "0.10.1" apply false
+    id "com.gradle.plugin-publish" version "0.12.0" apply false
     id "io.beekeeper.gradle.plugin" version "0.7.11"
 }
 


### PR DESCRIPTION
So the plugin can be actually published.

> * What went wrong:
> Execution failed for task ':beekeeper-code-analysis-plugin:publishPlugins'.
> > Failed to post to server.
>   Server responded with:
>   This version of the com.gradle.plugin-publish plugin is no longer supported due to a critical security vulnerability.
>   Please update to the latest version of the com.gradle.plugin-publish plugin found here:
>      https://plugins.gradle.org/plugin/com.gradle.plugin-publish
>   You can read more about this vulnerability here:
>      https://blog.gradle.org/plugin-portal-update