### PR TITLE
FUL-22325: remove spotbugs analysis from beekeeper plugin

### DIFF
--- a/beekeeper-plugin/build.gradle
+++ b/beekeeper-plugin/build.gradle
@@ -5,7 +5,6 @@ plugins {
 dependencies {
     compileOnly 'com.github.spotbugs:spotbugs-annotations:3.1.12'
 
-    implementation project(':beekeeper-code-analysis-plugin')
     implementation project(':beekeeper-formatter-plugin')
     implementation project(':beekeeper-ide-plugin')
     implementation project(':beekeeper-license-check-plugin')

--- a/beekeeper-plugin/src/main/java/io/beekeeper/gradle/plugin/BeekeeperPlugin.java
+++ b/beekeeper-plugin/src/main/java/io/beekeeper/gradle/plugin/BeekeeperPlugin.java
@@ -5,7 +5,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
 import io.beekeeper.formatter.FormatterPlugin;
-import io.beekeeper.gradle.code.CodeAnalysisPlugin;
 import io.beekeeper.gradle.licenses.LicenseCheckPlugin;
 import io.beekeeper.gradle.plugin.tasks.CheckVersionTask;
 import io.beekeeper.gradle.security.PatchVulnerableLibrariesPlugin;
@@ -41,7 +40,6 @@ public class BeekeeperPlugin implements Plugin<Project> {
     }
 
     private void applyPlugins(Project project) {
-        project.getPluginManager().apply(CodeAnalysisPlugin.class);
         project.getPluginManager().apply(FormatterPlugin.class);
         project.getPluginManager().apply(IdePlugin.class);
         project.getPluginManager().apply(LicenseCheckPlugin.class);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.caching=true
-version=0.8.4
+version=0.8.5


### PR DESCRIPTION
Since we are now running Sonarqube, Spotbugs is not needed anymore.
We will develop better intergrations with Sonarqube later on. 