### PR TITLE
FUL-22326-3: check for quarkus dependencies in all subprojects

### DIFF
--- a/beekeeper-security-plugin/src/main/java/io/beekeeper/gradle/security/SecurityPlugin.java
+++ b/beekeeper-security-plugin/src/main/java/io/beekeeper/gradle/security/SecurityPlugin.java
@@ -100,12 +100,24 @@ public class SecurityPlugin implements Plugin<Project> {
     }
 
     private boolean isQuarkusProject(Project project) {
-        return project
+        boolean hasQuarkusDependencies = project
             .getConfigurations()
             .stream()
             .map(Configuration::getAllDependencies)
             .flatMap(Collection::stream)
             .anyMatch(d -> QUARKUS_DEPENDENCY_GROUP.equals(d.getGroup()));
+
+        if (hasQuarkusDependencies) {
+            return true;
+        }
+
+        for (Project subProject : project.getSubprojects()) {
+            if (isQuarkusProject(subProject)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public static class BeekeeperSecurityExtension {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.caching=true
-version=0.8.7
+version=0.8.8


### PR DESCRIPTION
Dependency-check plugin bubbles up vulnerabilities from child projects to parent project. But the suppression list only applies to the current project so we need to check for quarkus dependencies in any subproject.