### PR TITLE
ENG-168: Fix jacoco issue applying to every project

### DIFF
--- a/beekeeper-testing-plugin/src/main/java/io/beekeeper/gradle/testing/TestingPlugin.java
+++ b/beekeeper-testing-plugin/src/main/java/io/beekeeper/gradle/testing/TestingPlugin.java
@@ -15,9 +15,11 @@ public class TestingPlugin implements Plugin<Project> {
     }
 
     private void applyJacoco(Project project) {
-        project.getPluginManager().apply("jacoco");
-        JacocoPluginExtension jacoco = project.getExtensions().getByType(JacocoPluginExtension.class);
-        jacoco.setToolVersion("0.8.4");
+        project.getPluginManager().withPlugin("java", it -> {
+            project.getPluginManager().apply("jacoco");
+            JacocoPluginExtension jacoco = project.getExtensions().getByType(JacocoPluginExtension.class);
+            jacoco.setToolVersion("0.8.4");
+        });
 
         project.afterEvaluate(this::configureJacoco);
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.caching=true
-version=0.9.4
+version=0.9.5


### PR DESCRIPTION
Jacoco applies to every project, which makes it difficult for cycleBomX
to execute correctly. This is because it tries to resolve the dependency
for jacoco for projects which do not have repositories define. Only
apply for java projects