### PR TITLE
Downgrade owasp dependency check to 5.3.2.1

### DIFF
--- a/beekeeper-security-plugin/build.gradle
+++ b/beekeeper-security-plugin/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation 'org.owasp:dependency-check-gradle:6.1.6'
+    implementation 'org.owasp:dependency-check-gradle:5.3.2.1'
     implementation 'org.cyclonedx:cyclonedx-gradle-plugin:1.1.3'
 }
 

--- a/beekeeper-security-plugin/src/test/groovy/io/beekeeper/gradle/security/SuppressionSpecification.groovy
+++ b/beekeeper-security-plugin/src/test/groovy/io/beekeeper/gradle/security/SuppressionSpecification.groovy
@@ -29,18 +29,16 @@ class SuppressionSpecification extends Specification {
         result.output.contains("appendSuppressionsQuarkus")
     }
 
-    // See FUL-27073
+    def "it should report suppressed vulnerability when not using common suppression"() {
+        given:
+        setUpBuildGradle(false)
 
-    // def "it should report suppressed vulnerability when not using common suppression"() {
-    //     given:
-    //     setUpBuildGradle(false)
+        when:
+        BuildResult result = runner.withArguments('dependencyCheckAnalyze').build()
 
-    //     when:
-    //     BuildResult result = runner.withArguments('dependencyCheckAnalyze').build()
-
-    //     then:
-    //     !result.output.contains("Found 0 vulnerabilities")
-    // }
+        then:
+        !result.output.contains("Found 0 vulnerabilities")
+    }
 
     def "it should not suppress Quarkus specific vulnerabilities when no dependency is present"() {
         given:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.caching=true
-version=0.9.17
+version=0.9.18


### PR DESCRIPTION
Builds are working again without the upgrade, so I think it's safer to do it in a controlled manner