### PR TITLE
FUL-32474: force cyclonedxBom task to run sequencially

### DIFF
--- a/beekeeper-security-plugin/src/main/java/io/beekeeper/gradle/security/BeekeeperCycloneDxPlugin.java
+++ b/beekeeper-security-plugin/src/main/java/io/beekeeper/gradle/security/BeekeeperCycloneDxPlugin.java
@@ -3,6 +3,9 @@ package io.beekeeper.gradle.security;
 import org.cyclonedx.gradle.CycloneDxPlugin;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
 
 public class BeekeeperCycloneDxPlugin implements Plugin<Project> {
 
@@ -11,6 +14,25 @@ public class BeekeeperCycloneDxPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getPluginManager().apply(CycloneDxPlugin.class);
+
+        Provider<LockService> lockService = project.getGradle()
+            .getSharedServices()
+            .registerIfAbsent(
+                "lockService",
+                LockService.class,
+                (spec) -> {
+                    spec.getMaxParallelUsages().set(1);
+                }
+            );
+
+        project.getTasks().getByPath("cyclonedxBom").usesService(lockService);
+    }
+
+    public static class LockService implements BuildService<BuildServiceParameters.None> {
+        @Override
+        public BuildServiceParameters.None getParameters() {
+            return null;
+        }
     }
 
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.caching=true
-version=0.9.27
+version=0.9.28


### PR DESCRIPTION
The BuildService is an incubating feature that is only available since Gradle 6.1. I assume that we can upgrade all the java repos to a version greater than that.

https://docs.gradle.org/current/javadoc/org/gradle/api/services/BuildService.html
