### PR TITLE
FUL-32474: CycloneDx is only needed in the root Project

### DIFF
--- a/beekeeper-security-plugin/src/main/java/io/beekeeper/gradle/security/BeekeeperCycloneDxPlugin.java
+++ b/beekeeper-security-plugin/src/main/java/io/beekeeper/gradle/security/BeekeeperCycloneDxPlugin.java
@@ -13,26 +13,8 @@ public class BeekeeperCycloneDxPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        project.getPluginManager().apply(CycloneDxPlugin.class);
-
-        Provider<LockService> lockService = project.getGradle()
-            .getSharedServices()
-            .registerIfAbsent(
-                "lockService",
-                LockService.class,
-                (spec) -> {
-                    spec.getMaxParallelUsages().set(1);
-                }
-            );
-
-        project.getTasks().getByPath("cyclonedxBom").usesService(lockService);
-    }
-
-    public static class LockService implements BuildService<BuildServiceParameters.None> {
-        @Override
-        public BuildServiceParameters.None getParameters() {
-            return null;
+        if (project.getRootProject().equals(project)) {
+            project.getPluginManager().apply(CycloneDxPlugin.class);
         }
     }
-
 }


### PR DESCRIPTION
the plugin automatically handles all the subprojects and the root project in the repository:
https://github.com/CycloneDX/cyclonedx-gradle-plugin/blob/master/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java#L150