### PR TITLE
FUL-33675: Upgrade to CycloneDX 1.5.0

### DIFF
--- a/beekeeper-security-plugin/build.gradle
+++ b/beekeeper-security-plugin/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     implementation 'org.owasp:dependency-check-gradle:5.3.2.1'
-    implementation 'org.cyclonedx:cyclonedx-gradle-plugin:1.4.0'
+    implementation 'org.cyclonedx:cyclonedx-gradle-plugin:1.5.0'
 }
 
 gradlePlugin {

--- a/beekeeper-security-plugin/build.gradle
+++ b/beekeeper-security-plugin/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     implementation 'org.owasp:dependency-check-gradle:5.3.2.1'
-    implementation 'org.cyclonedx:cyclonedx-gradle-plugin:1.5.0'
+    implementation 'com.cyclonedx:cyclonedx-gradle-plugin:1.5.0'
 }
 
 gradlePlugin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.caching=true
-version=0.9.31
+version=0.10.0


### PR DESCRIPTION
CycloneDX 1.5.0 was [released a few days ago](https://github.com/CycloneDX/cyclonedx-gradle-plugin/releases/tag/cyclonedx-gradle-plugin-1.5.0) with a fix for the `ConcurrentModificationException` it causes when running on projects that feature Quarkus 2.3+.

The new version includes a couple fixes that were made by a Quarkus contributor: https://github.com/CycloneDX/cyclonedx-gradle-plugin/pull/110 and https://github.com/CycloneDX/cyclonedx-gradle-plugin/pull/111.

This will allow us to finally upgrade to Quarkus 2.6.3.