### PR TITLE
Revert spotless plugin version

### DIFF
--- a/beekeeper-formatter-plugin/build.gradle
+++ b/beekeeper-formatter-plugin/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation group: 'com.diffplug.spotless', name: 'spotless-plugin-gradle', version: '6.8.0'
+    implementation group: 'com.diffplug.spotless', name: 'spotless-plugin-gradle', version: '6.3.0'
     implementation group: 'com.diffplug.durian', name: 'durian-io', version: '1.2.0'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.caching=true
-version=0.11.0
+version=0.11.1


### PR DESCRIPTION
Reverts the spotless plugin update from https://github.com/beekpr/beekeeper-gradle-plugins/pull/211 - this does not work