### PR TITLE
Gc 401 bump security plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ After that you should run `./gradlew publishToMavenLocal` this will deploy plugi
 
 ## Changelog
 
+### 0.13.0
+Bump security plugin dependencies:
+- dependency-check-gradle to 7.2.1
+- cyclonedx-gradle-plugin to 1.7.2
+
 ### 0.12.0
 Use google-java-format as a default formatter.
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ If you are migrating an existing beekeeper project to make use of this plugin, t
 
 ## Testing locally
 
+Please make sure you're using java 11:
+```
+$ java -version
+```
+
 To test locally you should add to build.gradle
 ```groovy
 id "maven-publish"

--- a/beekeeper-security-plugin/build.gradle
+++ b/beekeeper-security-plugin/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
-    implementation 'org.owasp:dependency-check-gradle:5.3.2.1'
-    implementation 'com.cyclonedx:cyclonedx-gradle-plugin:1.5.0'
+    implementation 'org.owasp:dependency-check-gradle:7.2.1'
+    implementation 'org.cyclonedx:cyclonedx-gradle-plugin:1.7.2'
 }
 
 gradlePlugin {

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@ subprojects {
     if(project.name.endsWith('-plugin')) {
         apply plugin: 'java-gradle-plugin'
         apply plugin: 'com.gradle.plugin-publish'
+        // uncomment for publishing locally
+        //apply plugin: 'maven-publish'
     }
 
     repositories {
@@ -22,6 +24,9 @@ subprojects {
         maven {
             url 'https://plugins.gradle.org/m2/'
         }
+
+        // uncomment for publishing locally
+        //mavenLocal()
     }
 
     dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.caching=true
-version=0.12.0
+version=0.13.0


### PR DESCRIPTION
Bumping security plugins:
- `dependency-check-gradle` to `7.2.1`
- `cyclonedx-gradle-plugin` to `1.7.2`

This will fix this issue that we also have: 
https://github.com/CycloneDX/cyclonedx-gradle-plugin/pull/152

Local testing with beekeeper-api-gateway-auth
![Screenshot 2022-10-12 at 17 56 02](https://user-images.githubusercontent.com/9157210/195391750-35b9db54-baa9-4040-93a7-05315090ed4e.png)
