### PR TITLE
FUL-38925 Apply `quarkus-jacoco` dependency to Quarkus-based projects and configure it to build consolidated reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ After that you should run `./gradlew publishToMavenLocal` this will deploy plugi
 
 ## Changelog
 
+## 0.15.0
+Apply `quarkus-jacoco` dependency to Quarkus-based projects and configure it to build consolidated reports from both
+`@QuarkusTest`-annotated and unit tests. 
+
 ## 0.14.0
 Update gradle to 7.6 and build to java 11
 

--- a/beekeeper-testing-plugin/src/main/java/io/beekeeper/gradle/testing/TestingPlugin.java
+++ b/beekeeper-testing-plugin/src/main/java/io/beekeeper/gradle/testing/TestingPlugin.java
@@ -1,8 +1,12 @@
 package io.beekeeper.gradle.testing;
 
+import java.util.List;
+
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.tasks.testing.Test;
 import org.gradle.testing.jacoco.plugins.JacocoPluginExtension;
+import org.gradle.testing.jacoco.plugins.JacocoTaskExtension;
 import org.gradle.testing.jacoco.tasks.JacocoReport;
 
 public class TestingPlugin implements Plugin<Project> {
@@ -19,12 +23,26 @@ public class TestingPlugin implements Plugin<Project> {
             project.getPluginManager().apply("jacoco");
             JacocoPluginExtension jacoco = project.getExtensions().getByType(JacocoPluginExtension.class);
             jacoco.setToolVersion("0.8.8");
+
+        });
+        project.getPluginManager().withPlugin("io.quarkus", it -> {
+            project.getDependencies().add("testImplementation", "io.quarkus:quarkus-jacoco");
         });
 
         project.afterEvaluate(this::configureJacoco);
     }
 
     private void configureJacoco(Project project) {
+        final boolean hasQuarkus = project.getPluginManager().hasPlugin("io.quarkus");
+
+        if (hasQuarkus) {
+            configureQuarkusJacoco(project);
+        } else {
+            configureStandaloneJacoco(project);
+        }
+    }
+
+    private void configureStandaloneJacoco(Project project) {
         project.getTasks().withType(JacocoReport.class, task -> {
             task.getReports().getXml().setEnabled(true);
             task.getReports().getCsv().setEnabled(true);
@@ -32,4 +50,21 @@ public class TestingPlugin implements Plugin<Project> {
         });
     }
 
+    private void configureQuarkusJacoco(Project project) {
+        // Quarkus-based projects use two versions of Jacoco:
+        // - standalone version for unit tests
+        // - Quarkus-provided version for tests annotated with @QuarkusTest
+        // See: https://quarkus.io/guides/tests-with-coverage#coverage-for-tests-not-using-quarkustest
+        // The Quarkus' version is further configured by the quarkus-beekeeper-api-convention extension.
+
+        project.getTasks().withType(Test.class, task -> {
+            final JacocoTaskExtension jacoco = task.getExtensions().getByType(JacocoTaskExtension.class);
+            jacoco.setExcludeClassLoaders(List.of("*QuarkusClassLoader"));
+            jacoco.setDestinationFile(project.getLayout().getBuildDirectory().file("reports/jacoco/test.exec").get().getAsFile());
+        });
+
+        project.getTasks().withType(JacocoReport.class, task -> {
+            task.setEnabled(false);
+        });
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.caching=true
-version=0.14.0
+version=0.15.0


### PR DESCRIPTION
Apply `quarkus-jacoco` dependency to Quarkus-based projects and configure it to build consolidated reports.

The configuration is done according to https://quarkus.io/guides/tests-with-coverage#coverage-for-tests-not-using-quarkustest both in this repository (configuring the regular Jacoco plugin), and in our Quarkus extensions (https://github.com/beekpr/beekeeper-quarkus-extensions/pull/197).

All of the changes made fixes code coverage calculation for Quarkus-based projects.
