### PR TITLE
FUL-000: Include hibernate-validator by default

### DIFF
--- a/beekeeper-quarkus-plugin/src/main/java/io/beekeeper/gradle/quarkus/QuarkusDependencies.java
+++ b/beekeeper-quarkus-plugin/src/main/java/io/beekeeper/gradle/quarkus/QuarkusDependencies.java
@@ -27,6 +27,7 @@ public class QuarkusDependencies {
             "org.zalando:problem",
             "org.zalando:jackson-datatype-problem",
             "io.beekeeper:quarkus-beekeeper-api-convention",
+            "io.quarkus:quarkus-hibernate-validator",
             "io.quarkus:quarkus-smallrye-openapi"
         );
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.caching=true
-version=0.15.3
+version=0.15.4


### PR DESCRIPTION
In order to have working validation (e.g. `@NotNull` annotation) on our JAX-RS interfaces, projects need to include `quarkus-hibernate-validator`:

![Screenshot 2023-11-21 at 11 44 20](https://github.com/beekpr/beekeeper-gradle-plugins/assets/6545258/f1a64f0b-24af-40d1-829c-12443659eb5a)

_Forgetting to do this will result in any validation annotation getting ignored._

Change: Include the `quarkus-hibernate-validator` if you use `beekeeperQuarkus.service`