### PR TITLE
BG-67: Bump spotless plugin

### DIFF
--- a/beekeeper-formatter-plugin/build.gradle
+++ b/beekeeper-formatter-plugin/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation group: 'com.diffplug.spotless', name: 'spotless-plugin-gradle', version: '6.11.0'
+    implementation group: 'com.diffplug.spotless', name: 'spotless-plugin-gradle', version: '6.25.0'
     implementation group: 'com.diffplug.durian', name: 'durian-io', version: '1.2.0'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.caching=true
-version=0.15.5
+version=0.15.6


### PR DESCRIPTION
Version bump for `spotless-plugin-gradle` to play better with Java 21 based projects